### PR TITLE
Took some inspiration from yaml-env-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 user-config.yml
 node_modules/
 .test/
+lib/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 user-config.yml
 node_modules/
+.test/

--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@ configuration.
 
 The **configuration format** looks as follows.
 ```yaml
-Defaults:
+defaults:
   hostname:     localhost
   port:         8080
-Profiles:
-  production:
-    hostname:   !env HOSTNAME
-    port:       !env:number PORT
-  test:
-    hostname:   localhost
-    port:       1234
+production: # profile 'production'
+  hostname:   !env HOSTNAME
+  port:       !env:number PORT
+test: # profile 'test'
+  hostname:   localhost
+  port:       1234
 ```
 The syntax extensions `!env <name>` is replaced with the value of the
 environment variable `<name>`. This is further extended to support loading
@@ -62,9 +61,9 @@ the configuration loader complain about missing files, but it will complain
 about ill formated files and missing profiles.
 
 If you specify `{profile: 'test'}` when loading the example configuration file
-listed at the top of this document, the loader will first load the `Defaults`
-section and then merge in values from the `Profiles.test` section overwriting
-values set in `Defaults`.
+listed at the top of this document, the loader will first load the `defaults`
+section and then merge in values from the `test` section overwriting
+values set in `defaults`.
 
 If there is both a `config.yml` and `user-config.yml` file, the `config.yml`
 will be loaded first and have the profile merged, before the `user-config.yml`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-config",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "Configuration loader that injects env variables into YAML",
   "license": "MPL-2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -14,20 +14,19 @@ let assert = require('assert');
  *     'config.yml',        // Defaults are relative to process.cwd
  *     'user-config.yml'
  *   ]
- *   profile:  undefined,   // Profile to apply
+ *   profile:  process.env.NODE_ENV, // Profile to apply
  *   env:      process.env  // Environment variables (mapping string to strings)
  * }
  * ```
  *
  * Configuration Format:
  * ```yaml
- * Defaults:
+ * defaults:
  *   hostname:     localhost
  *   port:         8080
- * Profiles:
- *   production:
- *     hostname:   example.com
- *     port:       !env:number PORT
+ * production:
+ *   hostname:   example.com
+ *   port:       !env:number PORT
  * ```
  *
  * The following special YAML types can be used to load from environment
@@ -51,7 +50,7 @@ let config = (options) => {
       'config.yml',
       'user-config.yml'
     ],
-    profile:  undefined,
+    profile:  process.env.NODE_ENV || undefined,
     env:      process.env
   });
   assert(options.files instanceof Array, "Expected an array of files");
@@ -158,15 +157,15 @@ let config = (options) => {
       throw new Error("Can't parse YAML from: " + file + " " + err.toString());
     }
     // Add defaults to list of configurations if present
-    if (data.Defaults) {
-      assert(typeof(data.Defaults) === 'object',
-             "'Defaults' must be an object");
-      cfgs.unshift(data.Defaults);
+    if (data.defaults) {
+      assert(typeof(data.defaults) === 'object',
+             "'defaults' must be an object");
+      cfgs.unshift(data.defaults);
     }
 
     // Add profile to list of configurations, if it is given
-    if (data.Profiles && options.profile && data.Profiles[options.profile]) {
-      let profile = data.Profiles[options.profile];
+    if (options.profile && data[options.profile]) {
+      let profile = data[options.profile];
       assert(typeof(profile) === 'object', "profile must be an object");
       cfgs.unshift(profile);
     }

--- a/test/test-env.yml
+++ b/test/test-env.yml
@@ -1,4 +1,4 @@
-Defaults:
+defaults:
   text:       !env           ENV_VARIABLE
   text2:      !env:string    ENV_VARIABLE
   number:     !env:number    ENV_NUMBER

--- a/test/test-profile.yml
+++ b/test/test-profile.yml
@@ -1,9 +1,8 @@
-Defaults:
+defaults:
   text:
     - Hello
     - World
-Profiles:
-  danish:
-    text:
-      - Hej
-      - Verden
+danish:
+  text:
+    - Hej
+    - Verden

--- a/test/test.yml
+++ b/test/test.yml
@@ -1,5 +1,4 @@
-Defaults:
+defaults:
   text:
     - Hello
     - World
-Profiles:


### PR DESCRIPTION
Notable changes is the format which is now:
```yaml
defaults:
  hostname:     localhost
  port:         8080
production:
  hostname:   example.com
  port:       !env:number PORT
```
It's a tiny bit simpler... less indentation...

Also we now use `process.env.NODE_ENV` as the default profile... This is nice because `NODE_ENV` is intended to be `production` when in production express and other modules change behavior based on it. And heroku defaults `NODE_ENV=production`, so using this as the profile by default seems like a good choice..

I get that tests will likely still want to overwrite the profile to special test profile. Outside of that it should make it more node-like...